### PR TITLE
Change API_URL to a relative path for Nginx proxying

### DIFF
--- a/app.js
+++ b/app.js
@@ -3,7 +3,7 @@
 //
 angular.module('app', ['flowChart',])
 	// Change API_URL to a relative path so that Nginx handles /api proxying
-	.constant('API_URL', "http://127.0.0.1:8000/api")
+	.constant('API_URL', "/api")
 
 	//
 	// Simple service to create a prompt.


### PR DESCRIPTION
This pull request includes a small but significant change to the `app.js` file. The `API_URL` constant has been updated to use a relative path (`/api`) instead of an absolute URL (`http://127.0.0.1:8000/api`) to enable Nginx to handle `/api` proxying.